### PR TITLE
Upgrade Typescript to 4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,9 +1817,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "globby": "^10.0.1",
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
-    "typescript": "^3.6.2"
+    "typescript": "^4.0.2"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
## What does this change?
 
Upgrades Typescript to 4.0. Necessary to use [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html), which will be useful in a forthcoming PR.

## How to test

This is a no-op – the library should work as expected.