### PR TITLE
Hydrate image:get with hypermedia subresources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm install -g @guardian/grid-cli
 $ grid COMMAND
 running command...
 $ grid (-v|--version|version)
-@guardian/grid-cli/1.2.0 darwin-x64 node-v12.9.1
+@guardian/grid-cli/1.2.0 darwin-x64 node-v15.3.0
 $ grid --help [COMMAND]
 USAGE
   $ grid COMMAND
@@ -259,6 +259,8 @@ OPTIONS
   -p, --profile=profile  [default: default] Profile name
 
   -t, --thumbnail        show a thumbnail
+
+  --hydrate              Gets fields which are returned as uri's.
 ```
 
 _See code: [src/commands/image/get.ts](https://github.com/guardian/grid-cli/blob/v1.2.0/src/commands/image/get.ts)_

--- a/src/commands/image/get.ts
+++ b/src/commands/image/get.ts
@@ -18,13 +18,18 @@ export default class ImageGet extends ApiCommand {
   ]
 
   async run() {
-    const {args:{id},flags:{field,thumbnail}} = this.parse(ImageGet)
+    const {args:{id},flags:{field,thumbnail, hydrate}} = this.parse(ImageGet)
 
 
     const image = await this.fetchImage(id)
-    const hydrated = await this.hydrate(image)
 
-    await this.printImages([hydrated],field,thumbnail)
+    if (!hydrate) {
+      await this.printImages([image],field,thumbnail)
+return
+    }
+    const data = await this.hydrate(image.data)
+    await this.printImages([{...image,data}],field,thumbnail)
+
   }
 
   async hydrate(image: any) {
@@ -40,7 +45,7 @@ export default class ImageGet extends ApiCommand {
         const { uri } = value as { uri: string }
         const response = await this.http!.get(new URL(uri))
         const {data} = await response.json()
-        return [key, data]
+        return [key, { ...value, data }]
       } catch (e) {
         return [key, value]
       }

--- a/src/commands/image/get.ts
+++ b/src/commands/image/get.ts
@@ -9,7 +9,7 @@ export default class ImageGet extends ApiCommand {
     ...ApiCommand.flags,
     help: flags.help({ char: 'h' }),
     hydrate: flags.boolean({
-      description: "Gets fields which are returned as uri's."
+      description: "Gets fields which are returned as uris."
     })
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017",
+    "target": "es2019",
     "esModuleInterop": true
   },
   "include": [


### PR DESCRIPTION
for image:get there is now a --hydrate flag

when it is engaged, fields which are just `{uri:...}` will instead resolve `{uri:...,data:{the goods}}`