### PR TITLE
Bulk search & delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To run the development build of the script, you can run `npm run local`.
 # Commands
 <!-- commands -->
 * [`grid autocomplete [SHELL]`](#grid-autocomplete-shell)
+* [`grid bulk:delete INPUT OUTPUT FAILURES`](#grid-bulkdelete-input-output-failures)
 * [`grid bulk:rights INPUT RIGHTS OUTPUT FAILURES`](#grid-bulkrights-input-rights-output-failures)
 * [`grid collection:add-root NAME`](#grid-collectionadd-root-name)
 * [`grid collection:move-images FROM TO`](#grid-collectionmove-images-from-to)
@@ -93,6 +94,33 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.3.0/src/commands/autocomplete/index.ts)_
+
+## `grid bulk:delete INPUT OUTPUT FAILURES`
+
+Deletes images from a text file containing image ids
+
+```
+USAGE
+  $ grid bulk:delete [INPUT] [OUTPUT] [FAILURES] [-p <value>] [-f <value>] [-t] [-h] [-x]
+
+ARGUMENTS
+  INPUT     file to read, containing one grid id per line
+  OUTPUT    file to output results to
+  FAILURES  file to write bad ids to
+
+FLAGS
+  -f, --field=<value>...  key or link name to print from each returned image, if none given then image will be output as
+                          json
+  -h, --help              Show CLI help.
+  -p, --profile=<value>   [default: default] Profile name
+  -t, --thumbnail         show a thumbnail
+  -x, --hard-delete       permanently erase images
+
+DESCRIPTION
+  Deletes images from a text file containing image ids
+```
+
+_See code: [src/commands/bulk/delete.ts](https://github.com/guardian/grid-cli/blob/v1.4.0/src/commands/bulk/delete.ts)_
 
 ## `grid bulk:rights INPUT RIGHTS OUTPUT FAILURES`
 
@@ -229,14 +257,18 @@ Delete an image from Grid
 
 ```
 USAGE
-  $ grid image:delete [ID] [-p <value>] [-h]
+  $ grid image:delete [ID] [-p <value>] [-f <value>] [-t] [-h] [-x]
 
 ARGUMENTS
   ID  ID of image
 
 FLAGS
-  -h, --help             Show CLI help.
-  -p, --profile=<value>  [default: default] Profile name
+  -f, --field=<value>...  key or link name to print from each returned image, if none given then image will be output as
+                          json
+  -h, --help              Show CLI help.
+  -p, --profile=<value>   [default: default] Profile name
+  -t, --thumbnail         show a thumbnail
+  -x, --hard-delete       permanently delete image
 
 DESCRIPTION
   Delete an image from Grid
@@ -325,17 +357,20 @@ Search for an Image from the API
 
 ```
 USAGE
-  $ grid image:search [Q] [-p <value>] [-f <value>] [-t] [-h]
+  $ grid image:search [Q] [-p <value>] [-f <value>] [-t] [-h] [-n <value>] [-s <value>] [-o <value>]
 
 ARGUMENTS
   Q  Search query
 
 FLAGS
-  -f, --field=<value>...  key or link name to print from each returned image, if none given then image will be output as
-                          json
-  -h, --help              Show CLI help.
-  -p, --profile=<value>   [default: default] Profile name
-  -t, --thumbnail         show a thumbnail
+  -f, --field=<value>...    key or link name to print from each returned image, if none given then image will be output
+                            as json
+  -h, --help                Show CLI help.
+  -n, --maxResults=<value>  [default: 10]
+  -o, --output=<value>
+  -p, --profile=<value>     [default: default] Profile name
+  -s, --pageSize=<value>    [default: 10]
+  -t, --thumbnail           show a thumbnail
 
 DESCRIPTION
   Search for an Image from the API

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "posttest": "eslint . --ext .ts --config .eslintrc -f stylish",
     "prepack": "rm -rf lib && tsc -b && oclif manifest && oclif readme",
     "test": "echo NO TESTS",
-    "version": "oclif readme && git add README.md"
+    "version": "tsc -b && oclif readme && git add README.md"
   },
   "types": "lib/index.d.ts"
 }

--- a/script/update-readme.sh
+++ b/script/update-readme.sh
@@ -2,4 +2,7 @@
 
 set -e
 
+# force a recompilation, to ensure that oclif sees all written commands
+npx tsc -b
+
 npx oclif readme

--- a/src/base-commands/api.ts
+++ b/src/base-commands/api.ts
@@ -4,6 +4,7 @@ import terminalImage from 'terminal-image'
 import terminalLink from 'terminal-link'
 
 import HttpCommand from './http'
+import type { PageInfo } from '../types/paging'
 
 export default abstract class ApiCommand extends HttpCommand {
   static flags = {
@@ -67,10 +68,12 @@ export default abstract class ApiCommand extends HttpCommand {
     return this.http!.get(url).then(_ => _.json())
   }
 
-  protected async search(q: string) {
+  protected async search(q: string, pageInfo?: PageInfo) {
     const mainEndpoint = `${this.profile!.mediaApiHost}images`
 
-    const endpoint = `${mainEndpoint}?q=${q}`
+    const paging = pageInfo === undefined ? '' : `&offset=${pageInfo.page * pageInfo.size}&length=${pageInfo.size}`
+
+    const endpoint = `${mainEndpoint}?q=${q}${paging}`
     const url = new URL(endpoint)
     return this.http!.get(url).then(_ => _.json())
   }

--- a/src/base-commands/api.ts
+++ b/src/base-commands/api.ts
@@ -5,6 +5,7 @@ import terminalLink from 'terminal-link'
 
 import HttpCommand from './http'
 import type { PageInfo } from '../types/paging'
+import { createWriteStream } from 'fs'
 
 export default abstract class ApiCommand extends HttpCommand {
   static flags = {
@@ -20,7 +21,16 @@ export default abstract class ApiCommand extends HttpCommand {
     }),
   }
 
-  protected async printImages(images: any[], field: string[] | undefined, thumbnail: boolean) {
+  protected async printImages(images: any[], field: string[] | undefined, thumbnail: boolean, outputFile: string | undefined) {
+    const outputStream = outputFile ? createWriteStream(outputFile) : undefined
+    const writeOutput = (o: string): void => {
+      if (outputStream) {
+        outputStream.write(o + '\n')
+      } else {
+        process.stdout.write(o + '\n')
+      }
+    }
+
     const output = Promise.all(images.map(async image => {
       const out = field === undefined ? JSON.stringify(image, null, 2) :
         field.map(f => {
@@ -51,9 +61,9 @@ export default abstract class ApiCommand extends HttpCommand {
     }))
 
     for (const [fields, thumb] of await output) {
-      this.log(fields)
+      writeOutput(fields)
       if (thumb) {
-        this.log(thumb)
+        writeOutput(thumb)
       }
     }
   }

--- a/src/commands/bulk/delete.ts
+++ b/src/commands/bulk/delete.ts
@@ -1,0 +1,89 @@
+import { Flags } from '@oclif/core'
+import { createReadStream, createWriteStream, WriteStream } from 'fs'
+import lines from 'lines-async-iterator'
+
+import ApiCommand from '../../base-commands/api'
+
+export default class BulkDelete extends ApiCommand {
+  static description = 'Deletes images from a text file containing image ids'
+
+  static flags = {
+    ...ApiCommand.flags,
+    help: Flags.help({ char: 'h' }),
+    'hard-delete': Flags.boolean({
+      char: 'x',
+      description: 'permanently erase images'
+    }),
+  }
+
+  static args = [
+    { name: 'input', description: 'file to read, containing one grid id per line', required: true },
+    {
+      name: 'output',
+      description: 'file to output results to',
+      required: true,
+    },
+    {
+      name: 'failures',
+      description: 'file to write bad ids to',
+      required: true,
+    },
+  ]
+
+  async delete(id: string, hardDelete: boolean, output: WriteStream, failures: WriteStream) {
+    try {
+      await this.deleteImage(id, hardDelete)
+    } catch (error) {
+      this.log(`Failed to delete ${id} ${(error as Error).message}`)
+      failures.write(`${id}\n`)
+      output.write(`${id}\t${(error as Error).message}\n`)
+      return false
+    }
+
+    output.write(`${id}\tSUCCESS\n`)
+
+    return true
+  }
+
+  async countLines(fname: string): Promise<number> {
+    const lf = '\n'.charCodeAt(0)
+    const stream = createReadStream(fname)
+    let lines = 0
+    stream.on('data', chunk => {
+      const data = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+      for (const c of data) {
+        if (c === lf) lines++
+      }
+    })
+    return new Promise((resolve, reject) => {
+      stream.on('end', () => resolve(lines))
+      stream.on('error', (e) => reject(e))
+    });
+  }
+
+  async run() {
+    const http = this.http
+    if (!http) {
+      this.log('No http, no anything.')
+      return false
+    }
+
+    const { flags, args } = await this.parse(BulkDelete)
+
+    const hardDelete = flags['hard-delete']
+
+    const lineCount = await this.countLines(args.input)
+
+    await this.confirmHardDelete(hardDelete)
+
+    const failures = createWriteStream(args.failures)
+
+    const output = createWriteStream(args.output)
+
+    let done = 0;
+    for await (const id of lines(args.input)) {
+      this.delete(id, hardDelete, output, failures)
+      this.log(`Successfully deleted ${id} - ${++done} / ${lineCount}`)
+    }
+  }
+}

--- a/src/commands/image/delete.ts
+++ b/src/commands/image/delete.ts
@@ -1,14 +1,16 @@
 import { Flags } from '@oclif/core'
-import { URL } from 'url'
+import ApiCommand from '../../base-commands/api'
 
-import HttpCommand from '../../base-commands/http'
-
-export default class ImageDelete extends HttpCommand {
+export default class ImageDelete extends ApiCommand {
   static description = 'Delete an image from Grid'
 
   static flags = {
-    ...HttpCommand.flags,
+    ...ApiCommand.flags,
     help: Flags.help({ char: 'h' }),
+    'hard-delete': Flags.boolean({
+      char: 'x',
+      description: 'permanently delete image',
+    }),
   }
 
   static args = [
@@ -16,18 +18,16 @@ export default class ImageDelete extends HttpCommand {
   ]
 
   async run() {
-    const { args } = await this.parse(ImageDelete)
+    const { args, flags } = await this.parse(ImageDelete)
 
-    const profile = this.profile!
-    const http = this.http!
+    const hardDelete = flags['hard-delete']
+    await this.confirmHardDelete(hardDelete)
 
-    const url = new URL(`${profile.mediaApiHost}images/${args.id}`)
-    const response = await http.delete(url)
-
-    if (response.status === 202) {
+    try {
+      await this.deleteImage(args.id, hardDelete)
       this.log('Image deleted')
-    } else {
-      this.error(JSON.stringify(response.json()))
+    } catch (error) {
+      this.error(error as Error)
     }
   }
 }

--- a/src/commands/image/search.ts
+++ b/src/commands/image/search.ts
@@ -10,6 +10,7 @@ export default class ImageSearch extends ApiCommand {
     help: Flags.help({ char: 'h' }),
     maxResults: Flags.integer({ char: 'n', default: 10, min: 1 }),
     pageSize: Flags.integer({ char: 's', default: 10, min: 1, max: 200 }),
+    output: Flags.string({ char: 'o' }),
   }
 
   static args = [
@@ -17,10 +18,9 @@ export default class ImageSearch extends ApiCommand {
   ]
 
   async run() {
-    const { args: { q }, flags: { field, thumbnail, maxResults, pageSize } } = await this.parse(ImageSearch)
+    const { args: { q }, flags: { field, thumbnail, maxResults, pageSize, output } } = await this.parse(ImageSearch)
     if (q === undefined) {
-      this.error('No search parameter given')
-      return
+      return this.error('No search parameter given')
     }
 
     this.log(`Searching for ${q}`)
@@ -38,6 +38,6 @@ export default class ImageSearch extends ApiCommand {
       }
     }
 
-    await this.printImages(results, field, thumbnail)
+    await this.printImages(results, field, thumbnail, output)
   }
 }

--- a/src/commands/image/search.ts
+++ b/src/commands/image/search.ts
@@ -8,7 +8,8 @@ export default class ImageSearch extends ApiCommand {
   static flags = {
     ...ApiCommand.flags,
     help: Flags.help({ char: 'h' }),
-
+    maxResults: Flags.integer({ char: 'n', default: 10, min: 1 }),
+    pageSize: Flags.integer({ char: 's', default: 10, min: 1, max: 200 }),
   }
 
   static args = [
@@ -16,15 +17,27 @@ export default class ImageSearch extends ApiCommand {
   ]
 
   async run() {
-    const { args: { q }, flags: { field, thumbnail } } = await this.parse(ImageSearch)
+    const { args: { q }, flags: { field, thumbnail, maxResults, pageSize } } = await this.parse(ImageSearch)
     if (q === undefined) {
       this.error('No search parameter given')
-      return 1
+      return
     }
 
     this.log(`Searching for ${q}`)
-    const results = await this.search(q)
+    let results: any[] = []
+    const maxPages = Math.ceil(maxResults / pageSize)
 
-    await this.printImages(results.data, field, thumbnail)
+    for (let i = 0; i < maxPages; i++) {
+      this.log(`performing search ${i + 1} of (at most) ${maxPages}`)
+      const thisPageSize = i === maxPages - 1 && maxResults % pageSize !== 0 ? maxResults % pageSize : pageSize
+      const page = await this.search(q, { page: i, size: thisPageSize })
+      results = [...results, ...page.data]
+      if (page.data.length < pageSize) {
+        this.log(`page ${i} returned less than ${pageSize} results, so terminating search loop now!`)
+        break
+      }
+    }
+
+    await this.printImages(results, field, thumbnail)
   }
 }

--- a/src/types/paging.ts
+++ b/src/types/paging.ts
@@ -1,0 +1,4 @@
+export type PageInfo = {
+  page: number,
+  size: number
+}


### PR DESCRIPTION
## What does this change?

- Improves image search command to include pagination to arbitrary depth, and outputting to file.
- Improves image delete command to allow hard-deletion
- Adds bulk image deletion command to delete all images according to a file containing a list of image ids.


make sure not to test against a profile pointing to prod!! the cli has very little protections from mistaken use
