### PR TITLE
Fix lint errors on bulk:delete

### DIFF
--- a/src/commands/bulk/delete.ts
+++ b/src/commands/bulk/delete.ts
@@ -12,7 +12,7 @@ export default class BulkDelete extends ApiCommand {
     help: Flags.help({ char: 'h' }),
     'hard-delete': Flags.boolean({
       char: 'x',
-      description: 'permanently erase images'
+      description: 'permanently erase images',
     }),
   }
 
@@ -57,8 +57,8 @@ export default class BulkDelete extends ApiCommand {
     })
     return new Promise((resolve, reject) => {
       stream.on('end', () => resolve(lines))
-      stream.on('error', (e) => reject(e))
-    });
+      stream.on('error', e => reject(e))
+    })
   }
 
   async run() {
@@ -80,7 +80,7 @@ export default class BulkDelete extends ApiCommand {
 
     const output = createWriteStream(args.output)
 
-    let done = 0;
+    let done = 0
     for await (const id of lines(args.input)) {
       this.delete(id, hardDelete, output, failures)
       this.log(`Successfully deleted ${id} - ${++done} / ${lineCount}`)


### PR DESCRIPTION
## What does this change?

A couple of lines in bulk:delete from #36 contain lint errors. (Oops) This blocks the release action from running.

A follow up PR will add automatically running lint as commit hooks and CI to prevent this from happening again.

## How to test

`npm run posttest` should now contain only warnings
