### PR TITLE
add an `--un-soft-delete` flag to delete and bulk delete commands

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomp
 
 ## `grid bulk:delete INPUT OUTPUT FAILURES`
 
-Deletes images from a text file containing image ids
+Deletes (or un-soft-deletes) images from a text file containing image ids
 
 ```
 USAGE
-  $ grid bulk:delete [INPUT] [OUTPUT] [FAILURES] [-p <value>] [-f <value>] [-t] [-h] [-x]
+  $ grid bulk:delete [INPUT] [OUTPUT] [FAILURES] [-p <value>] [-f <value>] [-t] [-h] [-x] [-u]
 
 ARGUMENTS
   INPUT     file to read, containing one grid id per line
@@ -145,10 +145,11 @@ FLAGS
   -h, --help              Show CLI help.
   -p, --profile=<value>   [default: default] Profile name
   -t, --thumbnail         show a thumbnail
+  -u, --un-soft-delete    un-soft-delete images
   -x, --hard-delete       permanently erase images
 
 DESCRIPTION
-  Deletes images from a text file containing image ids
+  Deletes (or un-soft-deletes) images from a text file containing image ids
 ```
 
 _See code: [src/commands/bulk/delete.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/bulk/delete.ts)_
@@ -284,11 +285,11 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.1
 
 ## `grid image:delete ID`
 
-Delete an image from Grid
+Delete (or un-soft-delete) an image from Grid
 
 ```
 USAGE
-  $ grid image:delete [ID] [-p <value>] [-f <value>] [-t] [-h] [-x]
+  $ grid image:delete [ID] [-p <value>] [-f <value>] [-t] [-h] [-x] [-u]
 
 ARGUMENTS
   ID  ID of image
@@ -299,10 +300,11 @@ FLAGS
   -h, --help              Show CLI help.
   -p, --profile=<value>   [default: default] Profile name
   -t, --thumbnail         show a thumbnail
+  -u, --un-soft-delete    un-soft-delete image
   -x, --hard-delete       permanently delete image
 
 DESCRIPTION
-  Delete an image from Grid
+  Delete (or un-soft-delete) an image from Grid
 ```
 
 _See code: [src/commands/image/delete.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/delete.ts)_

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ npm install -g @guardian/grid-cli
 $ grid COMMAND
 running command...
 $ grid (--version)
-@guardian/grid-cli/1.5.1 darwin-arm64 node-v16.17.0
+@guardian/grid-cli/1.6.0 darwin-arm64 node-v16.17.0
 $ grid --help [COMMAND]
 USAGE
   $ grid COMMAND
@@ -152,7 +152,7 @@ DESCRIPTION
   Deletes (or un-soft-deletes) images from a text file containing image ids
 ```
 
-_See code: [src/commands/bulk/delete.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/bulk/delete.ts)_
+_See code: [src/commands/bulk/delete.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/bulk/delete.ts)_
 
 ## `grid bulk:rights INPUT RIGHTS OUTPUT FAILURES`
 
@@ -179,7 +179,7 @@ DESCRIPTION
   Reads a text file containing image ids, and sets their usage rights.
 ```
 
-_See code: [src/commands/bulk/rights.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/bulk/rights.ts)_
+_See code: [src/commands/bulk/rights.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/bulk/rights.ts)_
 
 ## `grid collection:add-root NAME`
 
@@ -200,7 +200,7 @@ DESCRIPTION
   Add a root collection
 ```
 
-_See code: [src/commands/collection/add-root.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/collection/add-root.ts)_
+_See code: [src/commands/collection/add-root.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/collection/add-root.ts)_
 
 ## `grid collection:move-images FROM TO`
 
@@ -222,7 +222,7 @@ DESCRIPTION
   Move images from one collection to another
 ```
 
-_See code: [src/commands/collection/move-images.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/collection/move-images.ts)_
+_See code: [src/commands/collection/move-images.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/collection/move-images.ts)_
 
 ## `grid configuration:add`
 
@@ -242,7 +242,7 @@ DESCRIPTION
   Add a configuration profile
 ```
 
-_See code: [src/commands/configuration/add.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/configuration/add.ts)_
+_See code: [src/commands/configuration/add.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/configuration/add.ts)_
 
 ## `grid configuration:read`
 
@@ -261,7 +261,7 @@ DESCRIPTION
   Echos current config
 ```
 
-_See code: [src/commands/configuration/read.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/configuration/read.ts)_
+_See code: [src/commands/configuration/read.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/configuration/read.ts)_
 
 ## `grid help [COMMAND]`
 
@@ -307,7 +307,7 @@ DESCRIPTION
   Delete (or un-soft-delete) an image from Grid
 ```
 
-_See code: [src/commands/image/delete.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/delete.ts)_
+_See code: [src/commands/image/delete.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/delete.ts)_
 
 ## `grid image:download ID`
 
@@ -329,7 +329,7 @@ DESCRIPTION
   describe the command here
 ```
 
-_See code: [src/commands/image/download.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/download.ts)_
+_See code: [src/commands/image/download.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/download.ts)_
 
 ## `grid image:get [ID]`
 
@@ -354,7 +354,7 @@ DESCRIPTION
   Get an Image from the API
 ```
 
-_See code: [src/commands/image/get.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/get.ts)_
+_See code: [src/commands/image/get.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/get.ts)_
 
 ## `grid image:reingest ID`
 
@@ -382,7 +382,7 @@ DESCRIPTION
   Reingest an image already present in the images bucket
 ```
 
-_See code: [src/commands/image/reingest.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/reingest.ts)_
+_See code: [src/commands/image/reingest.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/reingest.ts)_
 
 ## `grid image:search [Q]`
 
@@ -409,7 +409,7 @@ DESCRIPTION
   Search for an Image from the API
 ```
 
-_See code: [src/commands/image/search.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/search.ts)_
+_See code: [src/commands/image/search.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/search.ts)_
 
 ## `grid image:upload IMAGE`
 
@@ -430,7 +430,7 @@ DESCRIPTION
   Upload an image to Grid. Can be a local file or a publicly accessible URL
 ```
 
-_See code: [src/commands/image/upload.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/upload.ts)_
+_See code: [src/commands/image/upload.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/upload.ts)_
 
 ## `grid image:visit ID`
 
@@ -451,7 +451,7 @@ DESCRIPTION
   View image in the browser
 ```
 
-_See code: [src/commands/image/visit.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/image/visit.ts)_
+_See code: [src/commands/image/visit.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/image/visit.ts)_
 
 ## `grid util:curl URL`
 
@@ -475,7 +475,7 @@ DESCRIPTION
   Make an authenticated request to a Grid URL. Assumes response is JSON.
 ```
 
-_See code: [src/commands/util/curl.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/util/curl.ts)_
+_See code: [src/commands/util/curl.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/util/curl.ts)_
 
 ## `grid util:id-file FILE`
 
@@ -495,5 +495,5 @@ DESCRIPTION
   Print the ID a file would get if uploaded to Grid
 ```
 
-_See code: [src/commands/util/id-file.ts](https://github.com/guardian/grid-cli/blob/v1.5.1/src/commands/util/id-file.ts)_
+_See code: [src/commands/util/id-file.ts](https://github.com/guardian/grid-cli/blob/v1.6.0/src/commands/util/id-file.ts)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/grid-cli",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/grid-cli",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/grid-cli",
   "description": "Helpful commands for interacting with Grid, The Guardian's image management tool.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": "The Guardian",
   "bin": {
     "grid": "bin/run"

--- a/src/base-commands/api.ts
+++ b/src/base-commands/api.ts
@@ -104,6 +104,20 @@ export default abstract class ApiCommand extends HttpCommand {
     throw new Error(`Failed to delete image ${id}, response status ${response.status}`)
   }
 
+  protected async unSoftDeleteImage(id: string) {
+    const endpoint = `${this.profile!.mediaApiHost}images/${id}/undelete`
+
+    const url = new URL(endpoint)
+
+    const response = await this.http!.put(url)
+
+    if (response.status === 202) {
+      return
+    }
+
+    throw new Error(`Failed to un-soft-delete image ${id}, response status ${response.status}`)
+  }
+
   protected async confirmHardDelete(hardDelete: boolean) {
     if (hardDelete) {
       const userIsSure = await CliUx.ux.confirm('Running with --hardDelete will completely erase these images. All information will be irrevocably lost. Are you sure? (y/n)')

--- a/src/commands/image/delete.ts
+++ b/src/commands/image/delete.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import ApiCommand from '../../base-commands/api'
 
 export default class ImageDelete extends ApiCommand {
-  static description = 'Delete an image from Grid'
+  static description = 'Delete (or un-soft-delete) an image from Grid'
 
   static flags = {
     ...ApiCommand.flags,
@@ -10,6 +10,10 @@ export default class ImageDelete extends ApiCommand {
     'hard-delete': Flags.boolean({
       char: 'x',
       description: 'permanently delete image',
+    }),
+    'un-soft-delete': Flags.boolean({
+      char: 'u',
+      description: 'un-soft-delete image',
     }),
   }
 
@@ -19,6 +23,15 @@ export default class ImageDelete extends ApiCommand {
 
   async run() {
     const { args, flags } = await this.parse(ImageDelete)
+
+    if (flags['un-soft-delete']) {
+      try {
+        await this.unSoftDeleteImage(args.id)
+        this.log('Image un-soft-deleted')
+      } catch (error) {
+        this.error(error as Error)
+      }
+    }
 
     const hardDelete = flags['hard-delete']
     await this.confirmHardDelete(hardDelete)

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -54,7 +54,7 @@ class Http {
     })
   }
 
-  public put = (url: URL, body: any) => {
+  public put = (url: URL, body?: any) => {
     return fetch(url.toString(), {
       method: 'PUT',
       headers: this.headers(),


### PR DESCRIPTION
…to for example, undoing eager reaper

✅  Tested successfully with @paperboyo un-soft-deleting 3k images which we accidentally soft reaped (when main prior to https://github.com/guardian/grid/pull/4287 was temporarily re-deployed without pausing reaper - long story).