### PR TITLE
spread the results data into the accumulator

### DIFF
--- a/src/commands/collection/move-images.ts
+++ b/src/commands/collection/move-images.ts
@@ -56,7 +56,7 @@ export default class CollectionMoveImages extends HttpCommand {
     while (offset === 0 || images.length < totalImages) {
       const results = await this.fetchImagesForCollection(collectionFrom, pageSize, offset)
       totalImages = results.total
-      images = [...images, results.data]
+      images = [...images, ...results.data]
       offset += pageSize
       this.log(`Fetched ${images.length} of ${totalImages} images`)
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

An oversight in https://github.com/guardian/grid-cli/pull/35/commits/908d7a675bd4ac935291af553ef9bb24014e224e#diff-2d39ef67d9e9cb172b03e3c7cb627fe54cb17d5aa9f770f8d7d165e084eca1daL58-R59 caused the fetched results data to be appended to the accumulator, rather than concatenated on 🤦 

## How to test

Run the `collection:move` command using the local run script (`npm run local -- collection:move-images -p test Observer Sport`) after setting up a TEST configuration

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
